### PR TITLE
Add support for generating JUnit test reports

### DIFF
--- a/bin/lux
+++ b/bin/lux
@@ -150,7 +150,8 @@ specs() ->
      {"--file_pattern", ".*\.lux" ++ [$$], string,                 mandatory},
      {"--root_dir",           undefined,   string,                 mandatory},
      {"--var",                undefined,   string,                 mandatory},
-     {"--tap",                undefined,   string,                 mandatory}
+     {"--tap",                undefined,   string,                 mandatory},
+     {"--junit",              false,       boolean,                none}
     ].
 
 enum(profile) ->
@@ -792,7 +793,8 @@ translate_opts([
      {"--file_pattern",       FilePattern},
      {"--root_dir",           _RootDir},
      {"--var",                Var},
-     {"--tap",                Tap}
+     {"--tap",                Tap},
+     {"--junit",              Junit}
     ]) ->
     Mode2 =
         if
@@ -835,7 +837,8 @@ translate_opts([
          {revision,           Revision},
          {hostname,           Hostname},
          {file_pattern,       FilePattern},
-         {tap,                Tap}
+         {tap,                Tap},
+         {junit,              Junit}
         ],
     {Files, lux_suite:args_to_opts(Opts, suite_style, [])}.
 

--- a/doc/cmd_line_opts.md
+++ b/doc/cmd_line_opts.md
@@ -86,6 +86,7 @@ Log management
 
     lux --annotate LogFile
     lux --history LogDir
+    lux --junit
 
 **--annotate LogFile**  
 Transforms textual log files into HTML format and annotates Lux script
@@ -101,3 +102,9 @@ file will be generated on the `LogDir` directory and is called
 `lux_history.html`. Its behavior can be customized by using the
 `--suite`, `--run`, `--revision` and `--hostname`
 [configuration parameters](#config_params).
+
+**--junit**  
+Generate a JUnit test report for the test run that can be used for example
+by Jenkins to show test result using the JUnit plugin. The generated test
+report will get the same name as the summary `LogFile` but with a
+`.junit.xml` extension added.

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,6 +17,7 @@ ERL_MODULES = \
 	lux_html_parse \
 	lux_html_utils \
 	lux_interpret \
+	lux_junit \
 	lux_log \
 	lux_suite \
 	lux_tap \

--- a/src/lux_junit.erl
+++ b/src/lux_junit.erl
@@ -1,0 +1,70 @@
+%% Copyright 2012-2017 Tail-f Systems AB
+%%
+%% See the file "LICENSE" for information on usage and redistribution
+%% of this file, and for a DISCLAIMER OF ALL WARRANTIES.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+-module(lux_junit).
+
+-export([write_report/2]).
+
+-include("lux.hrl").
+
+write_report(LogFile, _Opts) ->
+    File = lux_utils:normalize_filename(LogFile),
+    case lux_log:parse_summary_log(File) of
+        {ok, _Result, Groups, _ConfigSection, _FileInfo, _EventLogs} ->
+            Content = testsuites(Groups),
+            Filename = File ++ ".junit.xml",
+            file:write_file(Filename, Content);
+        {error, _File, _Reason} = Error ->
+            Error
+    end.
+
+testsuites(Groups) ->
+    ["<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+     "<testsuites>",
+     lists:map(fun testsuite/1, Groups),
+     "</testsuites>"].
+
+testsuite({test_group, _, Cases}) ->
+    Tests = erlang:integer_to_binary(erlang:length(Cases)),
+    ["<testsuite tests=\"", Tests, "\">",
+    lists:map(fun testcase/1, Cases),
+     "</testsuite>"].
+
+testcase({test_case, Filename, _, _, _, Result}) ->
+    ["<testcase ",
+     "classname=\"", classname(Filename), "\" ",
+     "name=\"", name(Filename), "\">",
+     body(Result),
+     "</testcase>"].
+
+classname(Filename) ->
+    case string:join(filename:split(filename:dirname(Filename)), ".") of
+        [$/, $. | ClassName] -> ClassName;
+        ClassName            -> ClassName
+    end.
+
+name(Filename) ->
+    filename:basename(Filename).
+
+body({result, {_, LineNo, Expected, Actual, Details}}) ->
+    ["<failure type=\"NoMatch\">",
+     "<![CDATA[",
+     "\nLine number: ", LineNo,
+     "\nExpected: ", Expected,
+     "\nActual: ", Actual,
+     "\nDetails:\n", join(Details, "\n"),
+     "]]>",
+     "</failure>"];
+body(_) ->
+    [].
+
+join([], _) ->
+    [];
+join([H | T], Separator) ->
+    JoinFun = fun(Element) ->
+                      [Separator, Element]
+              end,
+    [H | lists:flatmap(JoinFun, T)].

--- a/src/lux_junit.erl
+++ b/src/lux_junit.erl
@@ -6,49 +6,69 @@
 
 -module(lux_junit).
 
--export([write_report/2]).
+-export([write_report/3]).
 
 -include("lux.hrl").
 
-write_report(LogFile, _Opts) ->
+write_report(LogFile, RunDir, _Opts) ->
     File = lux_utils:normalize_filename(LogFile),
     case lux_log:parse_summary_log(File) of
         {ok, _Result, Groups, _ConfigSection, _FileInfo, _EventLogs} ->
-            Content = testsuites(Groups),
+            Content = testsuites(Groups, RunDir),
             Filename = File ++ ".junit.xml",
             file:write_file(Filename, Content);
         {error, _File, _Reason} = Error ->
             Error
     end.
 
-testsuites(Groups) ->
+testsuites(Groups, RunDir) ->
+    TestsuiteFun = fun(Group) ->
+                           testsuite(Group, RunDir)
+                   end,
     ["<?xml version=\"1.0\" encoding=\"utf-8\"?>",
      "<testsuites>",
-     lists:map(fun testsuite/1, Groups),
+     lists:flatmap(TestsuiteFun, Groups),
      "</testsuites>"].
 
-testsuite({test_group, _, Cases}) ->
+testsuite({test_group, _, Cases}, RunDir) ->
+    TestcaseFun = fun(Testcase) ->
+                          testcase(Testcase, RunDir)
+                  end,
     Tests = erlang:integer_to_binary(erlang:length(Cases)),
     ["<testsuite tests=\"", Tests, "\">",
-    lists:map(fun testcase/1, Cases),
-     "</testsuite>"].
+    lists:flatmap(TestcaseFun, Cases),
+     "</testsuite>"];
+testsuite(_, _) ->
+    [].
 
-testcase({test_case, Filename, _, _, _, Result}) ->
+testcase({result_case, Filename, Reason, _Details}, RunDir) ->
     ["<testcase ",
-     "classname=\"", classname(Filename), "\" ",
+     "classname=\"", classname(Filename, RunDir), "\" ",
+     "name=\"", name(Filename), "\">",
+     "<system-out>", Reason, "</system-out>",
+     "</testcase>"];
+testcase({test_case, Filename, _, _, _, Result}, RunDir) ->
+    ["<testcase ",
+     "classname=\"", classname(Filename, RunDir), "\" ",
      "name=\"", name(Filename), "\">",
      body(Result),
-     "</testcase>"].
+     "</testcase>"];
+testcase(_, _) ->
+    [].
 
-classname(Filename) ->
-    case string:join(filename:split(filename:dirname(Filename)), ".") of
-        [$/, $. | ClassName] -> ClassName;
-        ClassName            -> ClassName
+classname(Filename, RunDir) ->
+    DirName = lux_utils:drop_prefix(RunDir, filename:dirname(Filename)),
+    case string:join(filename:split(DirName), ".") of
+        "."                  -> "lux";
+        [$/, $. | ClassName] -> "lux." ++ ClassName;
+        ClassName            -> "lux." ++ ClassName
     end.
 
 name(Filename) ->
     filename:basename(Filename).
 
+body({result, skip}) ->
+    ["<skipped/>"];
 body({result, {_, LineNo, Expected, Actual, Details}}) ->
     ["<failure type=\"NoMatch\">",
      "<![CDATA[",
@@ -58,6 +78,19 @@ body({result, {_, LineNo, Expected, Actual, Details}}) ->
      "\nDetails:\n", join(Details, "\n"),
      "]]>",
      "</failure>"];
+body({error, Reason}) ->
+    ["<error message=\"error\" type=\"general_error\">",
+     "<![CDATA[",
+     join(Reason, "\n"),
+     "]]>",
+     "</error>"];
+body({error_line, LineNo, Reason}) ->
+    ["<error message=\"error\" type=\"general_error\">",
+     "<![CDATA[",
+     "Error at line ", LineNo,
+     join(Reason, "\n"),
+     "]]>",
+     "</error>"];
 body(_) ->
     [].
 

--- a/src/lux_suite.erl
+++ b/src/lux_suite.erl
@@ -207,7 +207,7 @@ full_run(#rstate{progress = Progress} = R, ConfigData, SummaryLog) ->
             EndConfig = [{'end time', [string], SuiteEndTime}],
             write_config_log(SummaryLog, ConfigData ++ EndConfig),
             lux_log:close_summary_log(SummaryFd, SummaryLog),
-            maybe_write_junit_report(R3, SummaryLog),
+            maybe_write_junit_report(R3, SummaryLog, ConfigData),
             annotate_final_summary_log(R3, Summary, HtmlPrio,
                                        SummaryLog, Results);
         {error, FileReason} ->
@@ -220,10 +220,11 @@ full_run(#rstate{progress = Progress} = R, ConfigData, SummaryLog) ->
             {error, SummaryLog, FileErr}
     end.
 
-maybe_write_junit_report(#rstate{junit = false}, _) ->
+maybe_write_junit_report(#rstate{junit = false}, _, _) ->
     ok;
-maybe_write_junit_report(#rstate{junit = true}, SummaryLog) ->
-    ok = lux_junit:write_report(SummaryLog, []).
+maybe_write_junit_report(#rstate{junit = true}, SummaryLog, ConfigData) ->
+    {run_dir, _, RunDir} = lists:keyfind(run_dir, 1, ConfigData),
+    ok = lux_junit:write_report(SummaryLog, RunDir, []).
 
 initial_res(_R, Exists, _ConfigData, SummaryLog, _Summary)
   when Exists =:= true ->

--- a/src/lux_suite.erl
+++ b/src/lux_suite.erl
@@ -54,7 +54,8 @@
          system_vars = lux_utils:system_vars()
                                     :: [string()], % ["name=val"]
          tap_opts = []              :: [string()],
-         tap                        :: term() % #tap{}
+         tap                        :: term(), % #tap{}
+         junit = false              :: boolean()
         }).
 
 run(Files, Opts, OrigArgs) when is_list(Files) ->
@@ -206,6 +207,7 @@ full_run(#rstate{progress = Progress} = R, ConfigData, SummaryLog) ->
             EndConfig = [{'end time', [string], SuiteEndTime}],
             write_config_log(SummaryLog, ConfigData ++ EndConfig),
             lux_log:close_summary_log(SummaryFd, SummaryLog),
+            maybe_write_junit_report(R3, SummaryLog),
             annotate_final_summary_log(R3, Summary, HtmlPrio,
                                        SummaryLog, Results);
         {error, FileReason} ->
@@ -217,6 +219,11 @@ full_run(#rstate{progress = Progress} = R, ConfigData, SummaryLog) ->
                                      file:format_error(FileReason)]),
             {error, SummaryLog, FileErr}
     end.
+
+maybe_write_junit_report(#rstate{junit = false}, _) ->
+    ok;
+maybe_write_junit_report(#rstate{junit = true}, SummaryLog) ->
+    ok = lux_junit:write_report(SummaryLog, []).
 
 initial_res(_R, Exists, _ConfigData, SummaryLog, _Summary)
   when Exists =:= true ->
@@ -453,6 +460,9 @@ parse_ropts([{Name, Val} = NameVal | T], R) ->
         tap when is_list(Val) ->
             TapOpts = [Val|R#rstate.tap_opts],
             parse_ropts(T, R#rstate{tap_opts = TapOpts});
+        junit when Val =:= true; Val =:= false ->
+            parse_ropts(T, R#rstate{junit = Val});
+
 
         %% case options
         _ ->
@@ -1272,6 +1282,8 @@ suite_config_type(Name) ->
             {ok, [string]};
         tap ->
             {ok, [{std_list, [string]}]};
+        junit ->
+            {ok, [{atom, [true, false]}]};
         _ ->
             {error, ?l2b(lists:concat(["Bad argument: ", Name]))}
     end.


### PR DESCRIPTION
Extend the log generation to support generating JUnit test reports that
can be used for example by Jenkins to show test results.