### PR TITLE
Add go+read for runpty debug

### DIFF
--- a/c_src/runpty.c
+++ b/c_src/runpty.c
@@ -193,7 +193,7 @@ int main(int argc, char *argv[])
     char* shellname = getenv("LUX_SHELLNAME");
     char* dbgfile;
     if (logdir) {
-        mkdir(logdir, 0700);
+        mkdir(logdir, 0755);
     } else {
         logdir = getcwd(NULL, 0);
     }
@@ -207,7 +207,7 @@ int main(int argc, char *argv[])
         perror("open runpty.dbg failed");
         exit(1);
     } else {
-        if (fchmod(dbgfd, S_IRUSR | S_IWUSR) < 0) {
+        if (fchmod(dbgfd, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH) < 0) {
             perror("chmod runpty.dbg failed");
             exit(1);
         }


### PR DESCRIPTION
Add read permission, for 'group' and 'other', on the directory and logs created when we run the default shell (runpty) with DEBUG.

We do this because when we run lux in a test environment we want to present the log files to other users than the test-runner, and in order to do so we need to add permissions.