### PR TITLE
Fixed problem with internal error when no [cleanup] is present.

### DIFF
--- a/src/lux_parse.erl
+++ b/src/lux_parse.erl
@@ -119,7 +119,7 @@ ensure_cleanup(P, RevCmds) when P#pstate.has_cleanup ->
 ensure_cleanup(_P, [] = RevCmds) ->
     RevCmds;
 ensure_cleanup(_P, [LastCmd | _] = RevCmds) ->
-    NoCleanup = LastCmd#cmd{type = no_cleanup},
+    NoCleanup = LastCmd#cmd{type = cleanup},
     [NoCleanup | RevCmds].
 
 extract_config(Cmd, _RevFile, _PosStack, Acc) ->

--- a/test/var_var.lux
+++ b/test/var_var.lux
@@ -1,0 +1,19 @@
+[doc Variables in variable names]
+
+[shell foo]
+    [loop n a b c]
+        !echo "foo=bar"
+        ?foo
+        ?foo=(.*)
+        [global foo_${n}=$1]
+        ?SH-PROMPT
+    [endloop]
+    !echo $foo_a
+    ?bar
+    ?SH-PROMPT
+    !echo $foo_b
+    ?bar
+    ?SH-PROMPT
+    !echo $foo_c
+    ?bar
+    ?SH-PROMPT


### PR DESCRIPTION
The simple lux script:

[shell z]
    !ls
    ?SH-PROMPT

[shell x]
    !echo "hej"
    ?hopp
    !ls
    ?SH-PROMPT

results in the INTERNAL ERROR

INTERNAL LUX ERROR: file write failed: the file server process is terminated
	<<>>
	[{lux_log,safe_write,4,[{file,"lux_log.erl"},{line,1540}]},
         {lux_shell,clog_recv,3,[{file,"lux_shell.erl"},{line,1279}]},
         {lux_shell,cleanup,2,[{file,"lux_shell.erl"},{line,643}]},
         {lux_shell,shell_loop,2,[{file,"lux_shell.erl"},{line,155}]},
         {lux_shell,init,2,[{file,"lux_shell.erl"},{line,109}]}]
         
 The above fix appears to solve the problem.
