### PR TITLE
Add support for deterministic build

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -99,6 +99,22 @@ and those parameters may be combined with
 
 >     make DESTDIR=/my/staging/area install
 
+Reproducible builds
+-------------------
+
+It is possible to build Lux deterministically, thus enabling
+reproducible builds.
+
+By configuring the build with the `--enable-deterministic-build` option
+the erlc flag `+deterministic` replaces the `+debug_info` erlc flag to
+generate deterministic beam files. Additionally the `runpty` program is
+stripped from non-deterministic content. After the configuration build
+normally, e.g.
+
+>     autoconf
+>     ./configure --enable-deterministic-build
+>     make
+
 Standalone installation
 -----------------------
 

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -25,6 +25,10 @@ trace:
 
 $(PROG): runpty.c
 	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $<
+ifeq ($(STRIP_RUNPTY), true)
+	strip $(PROG)
+	strip --remove-section=.note.gnu.build-id $(PROG)
+endif
 
 clean:
 	rm -rf $(PROG) ../priv/bin/runpty.dSYM core* *~

--- a/configure.in
+++ b/configure.in
@@ -95,6 +95,21 @@ if test "x$ERLC" = "xno"; then
   AC_MSG_ERROR([erlc: command not found])
 fi
 
+AC_ARG_ENABLE(deterministic_build,
+AS_HELP_STRING([--enable-deterministic-build],
+                [enable deterministic build,
+                 add +deterministic remove +debug_info]))
+
+DEBUGINFO_OR_DETERMINISTIC=+debug_info
+STRIP_RUNPTY=
+if test "x$enable_deterministic_build" = "xyes"; then
+    DEBUGINFO_OR_DETERMINISTIC=+deterministic
+    STRIP_RUNPTY=true
+fi
+
+AC_SUBST(DEBUGINFO_OR_DETERMINISTIC)
+AC_SUBST(STRIP_RUNPTY)
+
 ################################################################################
 # Doc
 

--- a/include.mk.in
+++ b/include.mk.in
@@ -55,13 +55,14 @@ LUX=$(APP_DIR)/bin/lux
 ERL="@ERL@"
 ERLC="@ERLC@"
 EMULATOR=beam
-ERLC_FLAGS += +warnings_as_errors +warn_unused_vars +debug_info
+ERLC_FLAGS += +warnings_as_errors +warn_unused_vars @DEBUGINFO_OR_DETERMINISTIC@
 
 # C
 CC=@CC@
 CFLAGS=@CFLAGS@
 LDFLAGS=@LDFLAGS@
 C_SRC_TARGET=@C_SRC_TARGET@
+STRIP_RUNPTY=@STRIP_RUNPTY@
 
 # Doc
 MARKDOWN=@MARKDOWN@


### PR DESCRIPTION
Enable reproducible builds by creating a deterministic build environment.

* Create a deterministic build environment with the new configure option --enable-deterministic-build.

Deterministic builds:

* Replaces +debug_info erlc flag with +deterministic.

* Strips runpty from non-deterministic data.