### PR TITLE
Replace dbg:stop_clear with dbg:stop

### DIFF
--- a/src/lux_trace.erl
+++ b/src/lux_trace.erl
@@ -135,7 +135,7 @@ start_tracer(TraceTarget) ->
 
 stop_trace() ->
     dbg:flush_trace_port(),
-    dbg:stop_clear().
+    dbg:stop().
 
 modules(AppDir, App, ExtraMods) ->
     AppStr = atom_to_list(App),


### PR DESCRIPTION
Stop_clear is removed in OTP 27. 

https://www.erlang.org/doc/general_info/scheduled_for_removal.html