### PR TITLE
POC of skip checking with variable set with regex

### DIFF
--- a/examples/skip.lux
+++ b/examples/skip.lux
@@ -5,5 +5,8 @@
 [config skip=SKIP_JAVA]
 [config skip_unless=TEST_SUNOS]
 
+[config skip=PRODUCT_VERSION~=1\.2\..*]
+
+
 [shell foo]
     ?bar

--- a/src/lux_parse.erl
+++ b/src/lux_parse.erl
@@ -492,7 +492,7 @@ opt_add_empty_warning(P, Cmd, OptMulti, EmptyBlob) ->
 
 parse_var(P, Fd, Cmd, Scope, String) ->
     case lux_utils:split_var(String, []) of
-        {Var, Val} ->
+        {Var, Val, _IsReg} ->
             {P, Cmd#cmd{type = variable, arg = {Scope, Var, Val}}};
         false ->
             LineNo = Cmd#cmd.lineno,

--- a/src/lux_utils.erl
+++ b/src/lux_utils.erl
@@ -196,11 +196,12 @@ do_lookup_var(_, _) ->
 
 test_var(Vars, VarVal) ->
     case split_var(VarVal, []) of
-        {Var, Val} ->
+        {Var, Val, IsReg} ->
             ok;
         false ->
             Var = VarVal,
-            Val = false
+            Val = false,
+            IsReg = false
     end,
     UnExpanded = [$$ | Var],
     try
@@ -210,6 +211,9 @@ test_var(Vars, VarVal) ->
             Val =:= false ->
                 %% Variable exists
                 {true, Var, Val};
+            IsReg ->
+                RegResult = re:run(Expanded, Val),
+                {RegResult /= nomatch, Var, Val};
             Val =:= Expanded ->
                 %% Value matches. Possible empty.
                 {true, Var, Val};
@@ -223,8 +227,10 @@ test_var(Vars, VarVal) ->
             {false, Var, Val}
     end.
 
+split_var([$~, $= | Val], Var) ->
+    {lists:reverse(Var), Val, true};
 split_var([$= | Val], Var) ->
-    {lists:reverse(Var), Val};
+    {lists:reverse(Var), Val, false};
 split_var([H | T], Var) ->
     split_var(T, [H | Var]);
 split_var([], _Var) ->


### PR DESCRIPTION
Allow set skip variable with regex, for dynamic skip the test on certain version.
By using `~=` when set skip variable value:
```
[config skip=PRODUCT_VERSION~=1\.2\..*]
```

This is just a PoC, would need some feedback on this if we want support this or not.